### PR TITLE
Fix potential XSS issue with arbitrary JS or HTML

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,9 @@ There's a frood who really knows where his towel is
 1.0b3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Fix potential XSS (arbitrary injection) issue by escaping and quoting all
+  attributes being set on the rendered portlet.
+  [davidjb]
 
 
 1.0b2 (2013-06-28)

--- a/src/collective/portlet/twitter/new.py
+++ b/src/collective/portlet/twitter/new.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from cgi import escape
 from zope.interface import implements
 
 from plone.portlets.interfaces import IPortletDataProvider
@@ -181,8 +182,8 @@ class Renderer(base.Renderer):
         attrs_str = ""
         attrs = self.get_attributes()
         for attr in attrs.keys():
-            attrs_str += "%s='%s' " % (attr, attrs[attr])
-        return "<a class='twitter-timeline'  %s >%s</a>" % (attrs_str,
+            attrs_str += '%s="%s" ' % (attr, escape(attrs[attr], quote=True))
+        return '<a class="twitter-timeline"  %s >%s</a>' % (attrs_str,
                                                             self.getText())
 
 

--- a/src/collective/portlet/twitter/tests/test_widget_new.py
+++ b/src/collective/portlet/twitter/tests/test_widget_new.py
@@ -39,11 +39,18 @@ class WidgetNewTest(unittest.TestCase):
                         "Renderer should be available by default.")
 
         self.assertEqual(renderer.get_html_tag(),
-                         "<a class='twitter-timeline'  href='http://twitter.com/plone' data-widget-id='0'  >Tweets by plone</a>")
+                         '<a class="twitter-timeline"  href="http://twitter.com/plone" data-widget-id="0"  >Tweets by plone</a>')
         html = renderer.render()
         self.assertIn('<dl', html)
         self.assertIn('<script>', html)
         self.assertIn(renderer.get_html_tag(), html)
+
+    def test_portlet_render_attibutes(self):
+        assignment = Assignment(data_id=u'"><script></script>', twitter=u"plone")
+        renderer = self._get_portlet_renderer(assignment)
+        html = renderer.get_html_tag()
+        self.assertIn('data-widget-id="&quot;&gt;&lt;script&gt;&lt;/script&gt;"', html)
+        self.assertNotIn('data-widget-id=""><script></script>"', html)
 
     def test_portlet_render_options(self):
         assignment = Assignment(data_id=u"0",


### PR DESCRIPTION
By creating a value for one of the portlet's attributes, such as the data ID, to close out the quoted data attribute, one can inject arbitrary content (JS, HTML, CSS) onto a page.  A value might be:

```
'><script>alert('xss')</script><a data-foo='
```

and the given <script> tag will execute on the resulting page where the Twitter portlet is located.

Escaping the HTML entities for each attribute, and ensuring the attribute is correctly quoted (they are), will prevent this XSS issue.
